### PR TITLE
set encoding header to utf-8

### DIFF
--- a/lib/htmldiff.rb
+++ b/lib/htmldiff.rb
@@ -1,3 +1,4 @@
+# encoding=utf-8 
 module HTMLDiff
 
   Match = Struct.new(:start_in_old, :start_in_new, :size)
@@ -286,7 +287,7 @@ module HTMLDiff
             words << current_word unless current_word.empty?
             current_word = char
             mode = :whitespace
-          elsif /[\S\#@]+/i.match char
+          elsif /[\w\#@]+/i.match char
             current_word << char
           else
             words << current_word unless current_word.empty?

--- a/lib/htmldiff.rb
+++ b/lib/htmldiff.rb
@@ -286,7 +286,7 @@ module HTMLDiff
             words << current_word unless current_word.empty?
             current_word = char
             mode = :whitespace
-          elsif /[\w\#@]+/i.match char
+          elsif /[\S\#@]+/i.match char
             current_word << char
           else
             words << current_word unless current_word.empty?


### PR DESCRIPTION
have put encoding to utf-8 for timetravel version, same for this. Then the /[\w#@]+/i.match char matches utf-8 characters as well.
